### PR TITLE
Drop `datatype` as a dependency

### DIFF
--- a/unitconv.egg
+++ b/unitconv.egg
@@ -2,7 +2,7 @@
 ((synopsis "Conversion of units of measurement")
  (license "LGPL-3")
  (category math)
- (dependencies datatype matchable)
+ (dependencies matchable)
  (test-dependencies test)
  (author "Ivan Raikov")
  (components

--- a/unitconv.scm
+++ b/unitconv.scm
@@ -341,7 +341,7 @@
 	
 
    (import scheme (chicken base) (chicken syntax) (only (chicken format) fprintf) srfi-4)
-   (import datatype matchable)
+   (import matchable)
    (import-for-syntax (chicken string) matchable)
    
 (define pi 3.14159265358979)


### PR DESCRIPTION
Hey there!

It seems the `datatype` egg is no longer used. I assume it was used in C4 for `define-record-type`, but that's now in `chicken.base` [(docs)](https://api.call-cc.org/5/doc/chicken/base/define-record-type).

I've been using both this change and another one I'm gonna make a PR for later, and so far I've had no problems. If you could, before merging, it would be good if you to tried using this branch for a while too, as you surely use the egg more than me, and would be a better "battle-tester".