### PR TITLE
Replace `define-record-printer` with `set-record-printer!`

### DIFF
--- a/unitconv.scm
+++ b/unitconv.scm
@@ -366,12 +366,13 @@
   (name quantity-name)
   (int quantity-int))
 
-(define-record-printer (quantity x out)
-  (if (zero? (quantity-int x))
-      (fprintf out "#(quantity Unity)")
-      (fprintf out "#(quantity ~S ~S)"
-	       (quantity-name x)
-	       (quantity-int x))))
+(set-record-printer! quantity
+  (lambda (x out)
+    (if (zero? (quantity-int x))
+        (fprintf out "#(quantity Unity)")
+        (fprintf out "#(quantity ~S ~S)"
+                 (quantity-name x)
+                 (quantity-int x)))))
 
 
 ;; The number of base quantities defined
@@ -513,15 +514,16 @@
 			 '()))))
 
   
-(define-record-printer (unit x out)
-  (let ((dims     (unit-dims x))
-	(abbrevs  (unit-abbrevs x)))
-    (if (null? abbrevs)
-	(fprintf out "#(unit ~S " (unit-name x))
-	(fprintf out "#(unit ~S ~S " (unit-name x) (unit-abbrevs x)))
-    (fprintf out "[~S] ~S)"
-	   (quantity-name dims)
-	   (unit-factor x))))
+(set-record-printer! unit
+  (lambda (x out)
+    (let ((dims     (unit-dims x))
+          (abbrevs  (unit-abbrevs x)))
+      (if (null? abbrevs)
+          (fprintf out "#(unit ~S " (unit-name x))
+          (fprintf out "#(unit ~S ~S " (unit-name x) (unit-abbrevs x)))
+      (fprintf out "[~S] ~S)"
+               (quantity-name dims)
+               (unit-factor x)))))
 
 
 

--- a/with-units.scm
+++ b/with-units.scm
@@ -64,10 +64,11 @@
   )
 
 
-(define-record-printer (with-units x out)
-      (fprintf out "#(~S ~S)"
-	       (with-units-value x)
-	       (with-units-unit x)))
+(set-record-printer! with-units
+  (lambda (x out)
+    (fprintf out "#(~S ~S)"
+             (with-units-value x)
+             (with-units-unit x))))
 
 (define (u:units x)
   (cond ((with-units? x) (with-units-unit x))


### PR DESCRIPTION
`chicken.base.define-record-printer` was deprecated in fc4ffafc16788bddf58bc48c6d784afc83d5b63b (either 5.1.1 or 5.2.0; I'm not sure yet which is right... I asked on IRC to see if anyone can clarify that), and `chicken.base.set-record-printer!` is now recommended.

This change is not very important, it's just preparation for the future, and it's not backwards compatible with early C5 versions either, but if you think backwards compatibility is worth it, I can put it in. Otherwise, if you just think it's not worth making this change right now, that's fine too, you can just close the PR.